### PR TITLE
DES-2429 Added writable prefs dir

### DIFF
--- a/base/bionic/openjdk11.dockerfile
+++ b/base/bionic/openjdk11.dockerfile
@@ -16,7 +16,7 @@ FROM adoptopenjdk:11-jre-hotspot-bionic
 # Base layer: prerequisites
 # Mendix directories
 RUN mkdir -p /opt/mendix/app/data/database /opt/mendix/app/data/files /opt/mendix/app/data/model-upload /opt/mendix/app/data/tmp && \
-    mkdir -p /opt/mendix/app/.java && \
+    mkdir -p /opt/mendix/app/.java/.userPrefs && \
     chmod g+rw /etc/passwd && \
     chgrp -R 0 /opt/mendix/app && \
     chmod -R g=u /opt/mendix/app

--- a/base/bionic/openjdk8.dockerfile
+++ b/base/bionic/openjdk8.dockerfile
@@ -16,7 +16,7 @@ FROM adoptopenjdk:8-jre-hotspot-bionic
 # Base layer: prerequisites
 # Mendix directories
 RUN mkdir -p /opt/mendix/app/data/database /opt/mendix/app/data/files /opt/mendix/app/data/model-upload /opt/mendix/app/data/tmp && \
-    mkdir -p /opt/mendix/app/.java && \
+    mkdir -p /opt/mendix/app/.java/.userPrefs && \
     chmod g+rw /etc/passwd && \
     chgrp -R 0 /opt/mendix/app && \
     chmod -R g=u /opt/mendix/app

--- a/base/rhel/openjdk11.dockerfile
+++ b/base/rhel/openjdk11.dockerfile
@@ -24,7 +24,7 @@ RUN microdnf update -y && \
 # Mendix directories
 RUN mkdir -p /opt/mendix/app && \
     mkdir -p /opt/mendix/app/data/database /opt/mendix/app/data/files /opt/mendix/app/data/model-upload /opt/mendix/app/data/tmp && \
-    mkdir -p /opt/mendix/app/.java && \
+    mkdir -p /opt/mendix/app/.java/.userPrefs && \
     chmod g+rw /etc/passwd && \
     chgrp -R 0 /opt/mendix/app && \
     chmod -R g=u /opt/mendix/app

--- a/base/rhel/openjdk8.dockerfile
+++ b/base/rhel/openjdk8.dockerfile
@@ -24,7 +24,7 @@ RUN microdnf update -y && \
 # Mendix directories
 RUN mkdir -p /opt/mendix/app && \
     mkdir -p /opt/mendix/app/data/database /opt/mendix/app/data/files /opt/mendix/app/data/model-upload /opt/mendix/app/data/tmp && \
-    mkdir -p /opt/mendix/app/.java && \
+    mkdir -p /opt/mendix/app/.java/.userPrefs && \
     chmod g+rw /etc/passwd && \
     chgrp -R 0 /opt/mendix/app && \
     chmod -R g=u /opt/mendix/app


### PR DESCRIPTION
This prevents the Mendix Runtime from showing the following **harmless** error messages when using an offline license:

```
Jun 22, 2020 11:46:51 AM java.util.prefs.FileSystemPreferences$1 run
WARNING: java.io.IOException: Permission denied
```

```
Exception in thread "Timer-0" java.lang.SecurityException: Could not lock User prefs. Lock file access denied.
        at java.prefs/java.util.prefs.FileSystemPreferences.checkLockFile0ErrorCode(FileSystemPreferences.java:956)
        at java.prefs/java.util.prefs.FileSystemPreferences.lockFile(FileSystemPreferences.java:944)
        at java.prefs/java.util.prefs.FileSystemPreferences.sync(FileSystemPreferences.java:748)
        at java.prefs/java.util.prefs.FileSystemPreferences.flush(FileSystemPreferences.java:843)
        at java.prefs/java.util.prefs.FileSystemPreferences.syncWorld(FileSystemPreferences.java:483)
        at java.prefs/java.util.prefs.FileSystemPreferences$3.run(FileSystemPreferences.java:450)
        at java.base/java.util.TimerThread.mainLoop(Timer.java:556)
        at java.base/java.util.TimerThread.run(Timer.java:506)
```

```
Exception in thread "Sync Timer Thread" java.lang.SecurityException: Could not lock User prefs. Lock file access denied.
        at java.prefs/java.util.prefs.FileSystemPreferences.checkLockFile0ErrorCode(FileSystemPreferences.java:956)
        at java.prefs/java.util.prefs.FileSystemPreferences.lockFile(FileSystemPreferences.java:944)
        at java.prefs/java.util.prefs.FileSystemPreferences.sync(FileSystemPreferences.java:748)
        at java.prefs/java.util.prefs.FileSystemPreferences.flush(FileSystemPreferences.java:843)
        at java.prefs/java.util.prefs.FileSystemPreferences.syncWorld(FileSystemPreferences.java:483)
        at java.prefs/java.util.prefs.FileSystemPreferences$4$1.run(FileSystemPreferences.java:461)
```