### PR TITLE
DES-3638 Add MxAgent for Mx9 Runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository can be cloned to create custom base images.
 
 The base image contains the Mendix Runtime and all dependencies required to build and run it.
 
-Currently, there are two types of base images:
+Currently, there is one type of base images:
 
 * `rhel` (based on [Red Hat Universal Base Image 8 Minimal](https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8/ubi-minimal))
 

--- a/base/rhel/openjdk11.dockerfile
+++ b/base/rhel/openjdk11.dockerfile
@@ -12,6 +12,16 @@ RUN cd /opt && \
     curl -sL "${DOWNLOAD_URL}mendix-${MX_VERSION}.tar.gz" | tar xz && \
     chown -R 0:0 /opt/${MX_VERSION}
 
+# Download MxAgent
+# Set owner to root (prevent modifications during runtime)
+# Note: MxAgent is a temporary solution until Runtime Tracing becomes available, and will be deprecated in Mendix 10
+ARG MXAGENT_DOWNLOAD_URL=https://cdn.mendix.com/mx-buildpack/mx-agent/mx-agent-v0.12.0.jar
+RUN if [ $(expr "$MX_VERSION" : '9\..*\..*\..*') -ne 0 ] ; then\
+    mkdir /opt/${MX_VERSION}/mxagent &&\
+    curl -sL -o /opt/${MX_VERSION}/mxagent/mx-agent.jar "${MXAGENT_DOWNLOAD_URL}" &&\
+    chown -R 0:0 /opt/${MX_VERSION}/mxagent; \
+fi
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 # Set the locale


### PR DESCRIPTION
Added the MxAgent jar to Mendix 9 Runtimes.
This allows the Mendix Operator to enable MxAgent and collect additional microflow execution metrics.

Fixed a readme typo.